### PR TITLE
Implement lesson feed API and lesson hub UX states

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -66,6 +66,26 @@ Users
   Updates theme preference.  
   Supabase backing: `PATCH /rest/v1/profiles?user_id=eq.<jwt.sub>`
 
+## Implemented Endpoints (continued)
+
+Lessons
+- `GET /lessons`  
+  Query: `q?`, `difficulty?`, `maxMinutes?`, `page?`, `pageSize?`  
+  Returns a filtered list of published lessons.
+- `GET /lessons/feed`  
+  Query: `q?`, `difficulty?`, `maxMinutes?`, `page?`, `pageSize?`  
+  Returns paginated feed contract: `{ items, total, page, pageSize }`.
+- `GET /lessons/search?q=...`  
+  Returns matching published lessons by title/description.
+- `GET /lessons/{id}`  
+  Returns one published lesson.
+- `GET /users/me/lessons/progress`  
+  Returns map of lesson id to progress percentage.
+- `GET /users/me/stats`  
+  Returns learning stats used by lesson hub cards.
+- `PUT /lessons/{id}/progress`  
+  Body: `{ progress }` where progress is 0-100. Upserts lesson progress row.
+
 ## Missing Endpoints (Required by Frontend)
 
 Feed and content
@@ -82,19 +102,13 @@ Feed and content
 - `POST /content/{id}/flag`
 
 Lessons
-- `GET /lessons`
-- `GET /lessons/search?q=...`
-- `GET /lessons/{id}`
 - `GET /lessons/{id}/sections`
 - `POST /lessons/{id}/enroll`
 - `POST /lessons/{id}/save`
-- `PUT /lessons/{id}/progress`
 
 User data
 - `GET /users/me/history`
 - `DELETE /users/me/history`
-- `GET /users/me/lessons/progress`
-- `GET /users/me/stats`
 - `GET /users/me/achievements`
 
 Categories

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -122,13 +122,32 @@ export const fetchBrowsingHistory = () =>
 
 export const clearBrowsingHistory = () => apiDelete<void>(`/users/me/history`);
 
-export const fetchLessons = () =>
-  withMockFallback("lessons", () => mockLessons, () => apiGet<Lesson[]>(`/lessons`));
+export type LessonFeedFilters = {
+  query?: string;
+  difficulty?: number;
+  maxMinutes?: number;
+  page?: number;
+  pageSize?: number;
+};
+
+const buildLessonQuery = (filters?: LessonFeedFilters) => {
+  const params = new URLSearchParams();
+  if (filters?.query) params.set("q", filters.query);
+  if (typeof filters?.difficulty === "number") params.set("difficulty", String(filters.difficulty));
+  if (typeof filters?.maxMinutes === "number") params.set("maxMinutes", String(filters.maxMinutes));
+  if (typeof filters?.page === "number") params.set("page", String(filters.page));
+  if (typeof filters?.pageSize === "number") params.set("pageSize", String(filters.pageSize));
+  const query = params.toString();
+  return query ? `/lessons?${query}` : `/lessons`;
+};
+
+export const fetchLessons = (filters?: LessonFeedFilters) =>
+  withMockFallback("lessons", () => mockLessons, () => apiGet<Lesson[]>(buildLessonQuery(filters)));
 
 export const searchLessons = (query: string) =>
   withMockFallback(
     "lesson-search",
-    () => mockLessons,
+    () => mockLessons.filter((lesson) => lesson.title.toLowerCase().includes(query.toLowerCase())),
     () => apiGet<Lesson[]>(`/lessons/search?q=${encodeURIComponent(query)}`)
   );
 

--- a/frontend/src/pages/LessonsPage.tsx
+++ b/frontend/src/pages/LessonsPage.tsx
@@ -1,31 +1,34 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { MainLayout } from '@/components/layout/MainLayout';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Progress } from '@/components/ui/progress';
-import { 
-  Search, 
-  Clock, 
-  Star, 
-  Users, 
+import { Label } from '@/components/ui/label';
+import {
+  Search,
+  Clock,
+  Star,
+  Users,
   ChevronRight,
   Trophy,
   Flame,
   BookOpen,
+  AlertCircle,
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import type { Lesson } from '@/types';
 import { fetchLessonProgress, fetchLessons, fetchUserStats, searchLessons } from '@/lib/api';
 
-// Backend: /api/lessons, /api/users/me/lessons/progress, /api/lessons/search
-// Dummy data is returned when mocks are enabled.
-
 const LessonsPage = () => {
   const [searchQuery, setSearchQuery] = useState('');
+  const [difficultyFilter, setDifficultyFilter] = useState<number | undefined>();
+  const [maxMinutesFilter, setMaxMinutesFilter] = useState<number | undefined>();
   const [lessons, setLessons] = useState<Lesson[]>([]);
   const [userProgress, setUserProgress] = useState<Record<string, number>>({});
+  const [loading, setLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [userStats, setUserStats] = useState({
     lessonsEnrolled: 0,
     lessonsCompleted: 0,
@@ -34,56 +37,79 @@ const LessonsPage = () => {
     hoursLearned: 0,
   });
 
+  const loadLessonFeed = useCallback(async () => {
+    setLoading(true);
+    setErrorMessage(null);
+    try {
+      const [lessonItems, progress, stats] = await Promise.all([
+        fetchLessons({ difficulty: difficultyFilter, maxMinutes: maxMinutesFilter }),
+        fetchLessonProgress(),
+        fetchUserStats(),
+      ]);
+      setLessons(lessonItems);
+      setUserProgress(progress);
+      setUserStats({
+        lessonsEnrolled: stats.lessonsEnrolled,
+        lessonsCompleted: stats.lessonsCompleted,
+        currentStreak: stats.currentStreak || 0,
+        conceptsMastered: stats.conceptsMastered,
+        hoursLearned: stats.hoursLearned || 0,
+      });
+    } catch (error) {
+      console.warn('Failed to load lesson feed', error);
+      setErrorMessage('Unable to load lessons right now. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [difficultyFilter, maxMinutesFilter]);
+
   useEffect(() => {
-    fetchLessons()
-      .then(setLessons)
-      .catch((error) => console.warn('Failed to load lessons', error));
-
-    fetchLessonProgress()
-      .then(setUserProgress)
-      .catch((error) => console.warn('Failed to load lesson progress', error));
-
-    fetchUserStats()
-      .then((stats) =>
-        setUserStats({
-          lessonsEnrolled: stats.lessonsEnrolled,
-          lessonsCompleted: stats.lessonsCompleted,
-          currentStreak: stats.currentStreak || 0,
-          conceptsMastered: stats.conceptsMastered,
-          hoursLearned: stats.hoursLearned || 0,
-        })
-      )
-      .catch((error) => console.warn('Failed to load user stats', error));
-  }, []);
+    void loadLessonFeed();
+  }, [loadLessonFeed]);
 
   const getDifficultyLabel = (level: number) => {
     switch (level) {
-      case 1: return { label: 'Beginner', color: 'bg-success' };
-      case 2: return { label: 'Intermediate', color: 'bg-warning' };
-      case 3: return { label: 'Advanced', color: 'bg-destructive' };
-      default: return { label: 'Beginner', color: 'bg-success' };
+      case 1:
+        return { label: 'Beginner', color: 'bg-success' };
+      case 2:
+        return { label: 'Intermediate', color: 'bg-warning' };
+      case 3:
+        return { label: 'Advanced', color: 'bg-destructive' };
+      default:
+        return { label: 'Beginner', color: 'bg-success' };
     }
   };
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!searchQuery.trim()) return;
+    if (!searchQuery.trim()) {
+      void loadLessonFeed();
+      return;
+    }
+    setLoading(true);
+    setErrorMessage(null);
     searchLessons(searchQuery)
       .then(setLessons)
-      .catch((error) => console.warn('Lesson search failed', error));
+      .catch((error) => {
+        console.warn('Lesson search failed', error);
+        setErrorMessage('Lesson search failed. Try another keyword.');
+      })
+      .finally(() => setLoading(false));
   };
+
+  const continueLearningLessons = useMemo(
+    () => lessons.filter((l) => userProgress[l.id] > 0 && userProgress[l.id] < 100),
+    [lessons, userProgress]
+  );
 
   return (
     <MainLayout>
-      <div className="container max-w-4xl mx-auto px-4 py-6 md:py-8 pb-safe">
-        {/* Header */}
+      <div className="container max-w-4xl mx-auto px-4 py-6 md:py-8 pb-safe" aria-live="polite">
         <div className="flex items-center justify-between mb-6">
           <div>
             <h1 className="text-2xl font-bold">Lesson Hub</h1>
             <p className="text-muted-foreground">Curated learning paths</p>
           </div>
-          
-          {/* Progress overview button */}
           <Link to="/profile/progress">
             <Button variant="outline" className="hidden sm:flex">
               <Trophy className="h-4 w-4 mr-2" />
@@ -92,77 +118,89 @@ const LessonsPage = () => {
           </Link>
         </div>
 
-        {/* Quick Stats */}
         <div className="grid grid-cols-3 sm:grid-cols-5 gap-3 mb-6">
-          <Card>
-            <CardContent className="p-3 text-center">
-              <BookOpen className="h-5 w-5 mx-auto mb-1 text-primary" />
-              <p className="text-lg font-bold">{userStats.lessonsEnrolled}</p>
-              <p className="text-xs text-muted-foreground">Enrolled</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-3 text-center">
-              <Trophy className="h-5 w-5 mx-auto mb-1 text-warning" />
-              <p className="text-lg font-bold">{userStats.lessonsCompleted}</p>
-              <p className="text-xs text-muted-foreground">Completed</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-3 text-center">
-              <Flame className="h-5 w-5 mx-auto mb-1 text-destructive" />
-              <p className="text-lg font-bold">{userStats.currentStreak}</p>
-              <p className="text-xs text-muted-foreground">Day Streak</p>
-            </CardContent>
-          </Card>
-          <Card className="hidden sm:block">
-            <CardContent className="p-3 text-center">
-              <Star className="h-5 w-5 mx-auto mb-1 text-accent" />
-              <p className="text-lg font-bold">{userStats.conceptsMastered}</p>
-              <p className="text-xs text-muted-foreground">Mastered</p>
-            </CardContent>
-          </Card>
-          <Card className="hidden sm:block">
-            <CardContent className="p-3 text-center">
-              <Clock className="h-5 w-5 mx-auto mb-1 text-secondary" />
-              <p className="text-lg font-bold">{userStats.hoursLearned}h</p>
-              <p className="text-xs text-muted-foreground">Learned</p>
-            </CardContent>
-          </Card>
+          <Card><CardContent className="p-3 text-center"><BookOpen className="h-5 w-5 mx-auto mb-1 text-primary" /><p className="text-lg font-bold">{userStats.lessonsEnrolled}</p><p className="text-xs text-muted-foreground">Enrolled</p></CardContent></Card>
+          <Card><CardContent className="p-3 text-center"><Trophy className="h-5 w-5 mx-auto mb-1 text-warning" /><p className="text-lg font-bold">{userStats.lessonsCompleted}</p><p className="text-xs text-muted-foreground">Completed</p></CardContent></Card>
+          <Card><CardContent className="p-3 text-center"><Flame className="h-5 w-5 mx-auto mb-1 text-destructive" /><p className="text-lg font-bold">{userStats.currentStreak}</p><p className="text-xs text-muted-foreground">Day Streak</p></CardContent></Card>
+          <Card className="hidden sm:block"><CardContent className="p-3 text-center"><Star className="h-5 w-5 mx-auto mb-1 text-accent" /><p className="text-lg font-bold">{userStats.conceptsMastered}</p><p className="text-xs text-muted-foreground">Mastered</p></CardContent></Card>
+          <Card className="hidden sm:block"><CardContent className="p-3 text-center"><Clock className="h-5 w-5 mx-auto mb-1 text-secondary" /><p className="text-lg font-bold">{userStats.hoursLearned}h</p><p className="text-xs text-muted-foreground">Learned</p></CardContent></Card>
         </div>
 
-        {/* Search */}
-        <form onSubmit={handleSearch} className="mb-6">
+        <form onSubmit={handleSearch} className="mb-4" aria-label="Search lessons">
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground" />
-            <Input
-              type="search"
-              placeholder="Search lessons..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-10 h-12 rounded-xl"
-            />
+            <Input type="search" placeholder="Search lessons..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} className="pl-10 h-12 rounded-xl" aria-label="Search lessons" />
           </div>
         </form>
 
-        {/* Continue Learning */}
-        {Object.values(userProgress).some(p => p > 0 && p < 100) && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6" role="group" aria-label="Lesson filters">
+          <div>
+            <Label htmlFor="difficulty-filter">Difficulty</Label>
+            <select
+              id="difficulty-filter"
+              className="w-full h-10 mt-1 rounded-md border border-input bg-background px-3"
+              value={difficultyFilter ?? ''}
+              onChange={(e) => setDifficultyFilter(e.target.value ? Number(e.target.value) : undefined)}
+            >
+              <option value="">All levels</option>
+              <option value="1">Beginner</option>
+              <option value="2">Intermediate</option>
+              <option value="3">Advanced</option>
+            </select>
+          </div>
+          <div>
+            <Label htmlFor="duration-filter">Max duration</Label>
+            <select
+              id="duration-filter"
+              className="w-full h-10 mt-1 rounded-md border border-input bg-background px-3"
+              value={maxMinutesFilter ?? ''}
+              onChange={(e) => setMaxMinutesFilter(e.target.value ? Number(e.target.value) : undefined)}
+            >
+              <option value="">Any duration</option>
+              <option value="10">Up to 10 min</option>
+              <option value="20">Up to 20 min</option>
+              <option value="30">Up to 30 min</option>
+            </select>
+          </div>
+        </div>
+
+        {loading && <p className="text-sm text-muted-foreground mb-6">Loading lesson feed…</p>}
+
+        {errorMessage && (
+          <Card className="mb-6 border-destructive">
+            <CardContent className="p-4 flex items-start gap-2 text-destructive">
+              <AlertCircle className="h-5 w-5 mt-0.5" />
+              <div>
+                <p className="font-medium">Could not load lesson feed</p>
+                <p className="text-sm">{errorMessage}</p>
+                <Button variant="outline" className="mt-3" onClick={() => void loadLessonFeed()}>Retry</Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {!loading && !errorMessage && lessons.length === 0 && (
+          <Card className="mb-6">
+            <CardContent className="p-6 text-center">
+              <p className="font-medium">No lessons matched your filters.</p>
+              <p className="text-sm text-muted-foreground">Try another search term or broaden the filters.</p>
+            </CardContent>
+          </Card>
+        )}
+
+        {continueLearningLessons.length > 0 && (
           <div className="mb-8">
             <h2 className="font-semibold mb-4">Continue Learning</h2>
-            {lessons.filter(l => userProgress[l.id] > 0 && userProgress[l.id] < 100).map((lesson) => (
+            {continueLearningLessons.map((lesson) => (
               <Link key={lesson.id} to={`/lessons/${lesson.id}`}>
                 <Card className="mb-3 hover:shadow-md transition-shadow">
                   <CardContent className="p-4">
                     <div className="flex items-center gap-4">
-                      <div className="w-16 h-16 rounded-xl gradient-primary flex items-center justify-center text-2xl">
-                        📚
-                      </div>
+                      <div className="w-16 h-16 rounded-xl gradient-primary flex items-center justify-center text-2xl">📚</div>
                       <div className="flex-1 min-w-0">
                         <h3 className="font-semibold truncate">{lesson.title}</h3>
                         <Progress value={userProgress[lesson.id]} className="h-2 mt-2" />
-                        <p className="text-sm text-muted-foreground mt-1">
-                          {userProgress[lesson.id]}% complete
-                        </p>
+                        <p className="text-sm text-muted-foreground mt-1">{userProgress[lesson.id]}% complete</p>
                       </div>
                       <ChevronRight className="h-5 w-5 text-muted-foreground flex-shrink-0" />
                     </div>
@@ -173,54 +211,26 @@ const LessonsPage = () => {
           </div>
         )}
 
-        {/* All Lessons */}
         <div>
           <h2 className="font-semibold mb-4">All Lessons</h2>
           <div className="grid gap-4 sm:grid-cols-2">
             {lessons.map((lesson) => {
               const difficulty = getDifficultyLabel(lesson.difficulty_level);
-              
               return (
                 <Link key={lesson.id} to={`/lessons/${lesson.id}`}>
                   <Card className="h-full hover:shadow-lg transition-shadow overflow-hidden">
-                    {/* Header Image */}
-                    <div className="h-32 gradient-secondary flex items-center justify-center">
-                      <span className="text-5xl">📖</span>
-                    </div>
-                    
+                    <div className="h-32 gradient-secondary flex items-center justify-center"><span className="text-5xl" aria-hidden="true">📖</span></div>
                     <CardContent className="p-4">
-                      {/* Badges */}
                       <div className="flex items-center gap-2 mb-2">
-                        <Badge className={`${difficulty.color} text-white text-xs`}>
-                          {difficulty.label}
-                        </Badge>
-                        {lesson.badge_name && (
-                          <Badge variant="outline" className="text-xs">
-                            🏆 {lesson.badge_name}
-                          </Badge>
-                        )}
+                        <Badge className={`${difficulty.color} text-white text-xs`}>{difficulty.label}</Badge>
+                        {lesson.badge_name && <Badge variant="outline" className="text-xs">🏆 {lesson.badge_name}</Badge>}
                       </div>
-                      
-                      {/* Title & Description */}
                       <h3 className="font-bold text-lg mb-1">{lesson.title}</h3>
-                      <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
-                        {lesson.description}
-                      </p>
-                      
-                      {/* Meta info */}
+                      <p className="text-sm text-muted-foreground line-clamp-2 mb-3">{lesson.description}</p>
                       <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                        <span className="flex items-center gap-1">
-                          <Clock className="h-4 w-4" />
-                          {lesson.estimated_minutes}m
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <Star className="h-4 w-4" />
-                          {lesson.xp_reward} XP
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <Users className="h-4 w-4" />
-                          {lesson.completion_count}
-                        </span>
+                        <span className="flex items-center gap-1"><Clock className="h-4 w-4" />{lesson.estimated_minutes}m</span>
+                        <span className="flex items-center gap-1"><Star className="h-4 w-4" />{lesson.xp_reward} XP</span>
+                        <span className="flex items-center gap-1"><Users className="h-4 w-4" />{lesson.completion_count}</span>
                       </div>
                     </CardContent>
                   </Card>

--- a/frontend/src/test/lessons-page.test.tsx
+++ b/frontend/src/test/lessons-page.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import LessonsPage from '@/pages/LessonsPage';
+
+vi.mock('@/components/layout/MainLayout', () => ({
+  MainLayout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/lib/api', () => ({
+  fetchLessons: vi.fn(),
+  fetchLessonProgress: vi.fn(),
+  fetchUserStats: vi.fn(),
+  searchLessons: vi.fn(),
+}));
+
+import { fetchLessonProgress, fetchLessons, fetchUserStats } from '@/lib/api';
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <LessonsPage />
+    </MemoryRouter>
+  );
+
+describe('LessonsPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders lesson cards from API', async () => {
+    vi.mocked(fetchLessons).mockResolvedValue([
+      {
+        id: 'lesson-1',
+        created_by: 'u1',
+        title: 'Brainrot Origins',
+        description: 'Understand where it began.',
+        header_media_url: null,
+        summary: null,
+        learning_objectives: null,
+        estimated_minutes: 10,
+        xp_reward: 100,
+        badge_name: null,
+        badge_icon_url: null,
+        difficulty_level: 1,
+        is_published: true,
+        completion_count: 12,
+        origin_content: null,
+        definition_content: null,
+        usage_examples: null,
+        lore_content: null,
+        evolution_content: null,
+        comparison_content: null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ]);
+    vi.mocked(fetchLessonProgress).mockResolvedValue({ 'lesson-1': 40 });
+    vi.mocked(fetchUserStats).mockResolvedValue({
+      lessonsEnrolled: 1,
+      lessonsCompleted: 0,
+      currentStreak: 1,
+      conceptsMastered: 3,
+      hoursLearned: 0.8,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Brainrot Origins').length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText('40% complete')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no lessons are returned', async () => {
+    vi.mocked(fetchLessons).mockResolvedValue([]);
+    vi.mocked(fetchLessonProgress).mockResolvedValue({});
+    vi.mocked(fetchUserStats).mockResolvedValue({
+      lessonsEnrolled: 0,
+      lessonsCompleted: 0,
+      currentStreak: 0,
+      conceptsMastered: 0,
+      hoursLearned: 0,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('No lessons matched your filters.')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/main/java/com/rotiprata/api/LessonController.java
+++ b/src/main/java/com/rotiprata/api/LessonController.java
@@ -1,0 +1,94 @@
+package com.rotiprata.api;
+
+import com.rotiprata.api.dto.LessonFeedResponse;
+import com.rotiprata.api.dto.LessonStatsResponse;
+import com.rotiprata.api.dto.UpdateLessonProgressRequest;
+import com.rotiprata.application.LessonService;
+import com.rotiprata.application.UserService;
+import com.rotiprata.domain.Lesson;
+import com.rotiprata.domain.Profile;
+import com.rotiprata.security.SecurityUtils;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class LessonController {
+    private final LessonService lessonService;
+    private final UserService userService;
+
+    public LessonController(LessonService lessonService, UserService userService) {
+        this.lessonService = lessonService;
+        this.userService = userService;
+    }
+
+    @GetMapping("/lessons")
+    public List<Lesson> lessons(
+        @RequestParam(value = "q", required = false) String query,
+        @RequestParam(value = "difficulty", required = false) Integer difficulty,
+        @RequestParam(value = "maxMinutes", required = false) Integer maxMinutes,
+        @RequestParam(value = "page", defaultValue = "1") int page,
+        @RequestParam(value = "pageSize", defaultValue = "24") int pageSize
+    ) {
+        return lessonService.fetchLessonFeed(SecurityUtils.getAccessToken(), query, difficulty, maxMinutes, page, pageSize);
+    }
+
+    @GetMapping("/lessons/feed")
+    public LessonFeedResponse lessonFeed(
+        @RequestParam(value = "q", required = false) String query,
+        @RequestParam(value = "difficulty", required = false) Integer difficulty,
+        @RequestParam(value = "maxMinutes", required = false) Integer maxMinutes,
+        @RequestParam(value = "page", defaultValue = "1") int page,
+        @RequestParam(value = "pageSize", defaultValue = "24") int pageSize
+    ) {
+        List<Lesson> items = lessonService.fetchLessonFeed(SecurityUtils.getAccessToken(), query, difficulty, maxMinutes, page, pageSize);
+        long total = lessonService.countLessons(SecurityUtils.getAccessToken(), query, difficulty, maxMinutes);
+        return new LessonFeedResponse(items, total, page, pageSize);
+    }
+
+    @GetMapping("/lessons/search")
+    public List<Lesson> searchLessons(@RequestParam("q") String query) {
+        return lessonService.searchLessons(SecurityUtils.getAccessToken(), query);
+    }
+
+    @GetMapping("/lessons/{id}")
+    public Lesson lessonById(@PathVariable("id") UUID id) {
+        return lessonService.getLessonById(SecurityUtils.getAccessToken(), id);
+    }
+
+    @GetMapping("/users/me/lessons/progress")
+    public Map<String, Integer> lessonProgress(@AuthenticationPrincipal Jwt jwt) {
+        UUID userId = SecurityUtils.getUserId(jwt);
+        return lessonService.getLessonProgressByLessonId(SecurityUtils.getAccessToken(), userId);
+    }
+
+    @GetMapping("/users/me/stats")
+    public LessonStatsResponse userLessonStats(@AuthenticationPrincipal Jwt jwt) {
+        UUID userId = SecurityUtils.getUserId(jwt);
+        Profile profile = userService.getOrCreateProfileFromJwt(jwt, SecurityUtils.getAccessToken());
+        return lessonService.getLessonStats(
+            SecurityUtils.getAccessToken(),
+            userId,
+            profile.getCurrentStreak() == null ? 0 : profile.getCurrentStreak(),
+            profile.getTotalHoursLearned() == null ? 0 : profile.getTotalHoursLearned().doubleValue()
+        );
+    }
+
+    @PutMapping("/lessons/{id}/progress")
+    public void updateLessonProgress(@AuthenticationPrincipal Jwt jwt, @PathVariable("id") UUID id, @Valid @RequestBody UpdateLessonProgressRequest request) {
+        UUID userId = SecurityUtils.getUserId(jwt);
+        int progress = request.progress() == null ? 0 : request.progress();
+        lessonService.upsertLessonProgress(SecurityUtils.getAccessToken(), userId, id, progress);
+    }
+}

--- a/src/main/java/com/rotiprata/api/dto/LessonFeedResponse.java
+++ b/src/main/java/com/rotiprata/api/dto/LessonFeedResponse.java
@@ -1,0 +1,6 @@
+package com.rotiprata.api.dto;
+
+import com.rotiprata.domain.Lesson;
+import java.util.List;
+
+public record LessonFeedResponse(List<Lesson> items, long total, int page, int pageSize) {}

--- a/src/main/java/com/rotiprata/api/dto/LessonStatsResponse.java
+++ b/src/main/java/com/rotiprata/api/dto/LessonStatsResponse.java
@@ -1,0 +1,9 @@
+package com.rotiprata.api.dto;
+
+public record LessonStatsResponse(
+    int lessonsEnrolled,
+    int lessonsCompleted,
+    int currentStreak,
+    int conceptsMastered,
+    double hoursLearned
+) {}

--- a/src/main/java/com/rotiprata/api/dto/UpdateLessonProgressRequest.java
+++ b/src/main/java/com/rotiprata/api/dto/UpdateLessonProgressRequest.java
@@ -1,0 +1,8 @@
+package com.rotiprata.api.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record UpdateLessonProgressRequest(
+    @Min(0) @Max(100) Integer progress
+) {}

--- a/src/main/java/com/rotiprata/application/LessonService.java
+++ b/src/main/java/com/rotiprata/application/LessonService.java
@@ -1,0 +1,211 @@
+package com.rotiprata.application;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.rotiprata.api.dto.LessonStatsResponse;
+import com.rotiprata.domain.Lesson;
+import com.rotiprata.domain.UserConceptMastered;
+import com.rotiprata.domain.UserLessonProgress;
+import com.rotiprata.infrastructure.supabase.SupabaseRestClient;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class LessonService {
+    private static final TypeReference<List<Lesson>> LESSON_LIST = new TypeReference<>() {};
+    private static final TypeReference<List<UserLessonProgress>> LESSON_PROGRESS_LIST = new TypeReference<>() {};
+    private static final TypeReference<List<UserConceptMastered>> CONCEPTS_MASTERED_LIST = new TypeReference<>() {};
+
+    private final SupabaseRestClient supabaseRestClient;
+
+    public LessonService(SupabaseRestClient supabaseRestClient) {
+        this.supabaseRestClient = supabaseRestClient;
+    }
+
+    public List<Lesson> fetchLessonFeed(String accessToken, String query, Integer difficulty, Integer maxMinutes, int page, int pageSize) {
+        int offset = Math.max(0, (page - 1) * pageSize);
+        var queryBuilder = UriComponentsBuilder.newInstance()
+            .queryParam("select", "*")
+            .queryParam("is_published", "eq.true")
+            .queryParam("order", "created_at.desc")
+            .queryParam("limit", pageSize)
+            .queryParam("offset", offset);
+
+        if (query != null && !query.isBlank()) {
+            String contains = "*" + sanitizeLikeValue(query.trim()) + "*";
+            queryBuilder.queryParam("or", "(title.ilike." + contains + ",description.ilike." + contains + ")");
+        }
+        if (difficulty != null) {
+            queryBuilder.queryParam("difficulty_level", "eq." + difficulty);
+        }
+        if (maxMinutes != null) {
+            queryBuilder.queryParam("estimated_minutes", "lte." + maxMinutes);
+        }
+
+        return supabaseRestClient.getList(
+            "lessons",
+            queryBuilder.build().getQuery(),
+            requireToken(accessToken),
+            LESSON_LIST
+        );
+    }
+
+    public long countLessons(String accessToken, String query, Integer difficulty, Integer maxMinutes) {
+        var queryBuilder = UriComponentsBuilder.newInstance()
+            .queryParam("select", "id")
+            .queryParam("is_published", "eq.true")
+            .queryParam("limit", 10000);
+
+        if (query != null && !query.isBlank()) {
+            String contains = "*" + sanitizeLikeValue(query.trim()) + "*";
+            queryBuilder.queryParam("or", "(title.ilike." + contains + ",description.ilike." + contains + ")");
+        }
+        if (difficulty != null) {
+            queryBuilder.queryParam("difficulty_level", "eq." + difficulty);
+        }
+        if (maxMinutes != null) {
+            queryBuilder.queryParam("estimated_minutes", "lte." + maxMinutes);
+        }
+
+        return supabaseRestClient.getList("lessons", queryBuilder.build().getQuery(), requireToken(accessToken), LESSON_LIST).size();
+    }
+
+    public List<Lesson> searchLessons(String accessToken, String query) {
+        return fetchLessonFeed(accessToken, query, null, null, 1, 24);
+    }
+
+    public Lesson getLessonById(String accessToken, UUID lessonId) {
+        List<Lesson> lessons = supabaseRestClient.getList(
+            "lessons",
+            UriComponentsBuilder.newInstance()
+                .queryParam("select", "*")
+                .queryParam("id", "eq." + lessonId)
+                .queryParam("is_published", "eq.true")
+                .build().getQuery(),
+            requireToken(accessToken),
+            LESSON_LIST
+        );
+        if (lessons.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Lesson not found");
+        }
+        return lessons.get(0);
+    }
+
+    public Map<String, Integer> getLessonProgressByLessonId(String accessToken, UUID userId) {
+        List<UserLessonProgress> progressRows = supabaseRestClient.getList(
+            "user_lesson_progress",
+            UriComponentsBuilder.newInstance()
+                .queryParam("select", "lesson_id,progress_percentage")
+                .queryParam("user_id", "eq." + userId)
+                .build().getQuery(),
+            requireToken(accessToken),
+            LESSON_PROGRESS_LIST
+        );
+
+        Map<String, Integer> progress = new HashMap<>();
+        for (UserLessonProgress row : progressRows) {
+            if (row.getLessonId() != null) {
+                progress.put(row.getLessonId().toString(), safeInt(row.getProgressPercentage()));
+            }
+        }
+        return progress;
+    }
+
+    public LessonStatsResponse getLessonStats(String accessToken, UUID userId, int currentStreak, double totalHoursLearned) {
+        List<UserLessonProgress> progressRows = supabaseRestClient.getList(
+            "user_lesson_progress",
+            UriComponentsBuilder.newInstance()
+                .queryParam("select", "status")
+                .queryParam("user_id", "eq." + userId)
+                .build().getQuery(),
+            requireToken(accessToken),
+            LESSON_PROGRESS_LIST
+        );
+
+        int completed = (int) progressRows.stream().filter(p -> "completed".equalsIgnoreCase(p.getStatus())).count();
+        int enrolled = progressRows.size();
+
+        int conceptsMastered = 0;
+        try {
+            conceptsMastered = supabaseRestClient.getList(
+                "user_concepts_mastered",
+                UriComponentsBuilder.newInstance()
+                    .queryParam("select", "id")
+                    .queryParam("user_id", "eq." + userId)
+                    .queryParam("limit", 10000)
+                    .build().getQuery(),
+                requireToken(accessToken),
+                CONCEPTS_MASTERED_LIST
+            ).size();
+        } catch (ResponseStatusException ignored) {
+            // Non-critical stats fallback when table/view is unavailable.
+        }
+
+        return new LessonStatsResponse(enrolled, completed, currentStreak, conceptsMastered, totalHoursLearned);
+    }
+
+    public void upsertLessonProgress(String accessToken, UUID userId, UUID lessonId, int progress) {
+        getLessonById(accessToken, lessonId);
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("progress_percentage", progress);
+        payload.put("status", progress >= 100 ? "completed" : progress > 0 ? "in_progress" : "not_started");
+        payload.put("last_accessed_at", OffsetDateTime.now());
+        if (progress > 0) {
+            payload.put("started_at", OffsetDateTime.now());
+        }
+        if (progress >= 100) {
+            payload.put("completed_at", OffsetDateTime.now());
+        }
+
+        List<UserLessonProgress> existing = supabaseRestClient.getList(
+            "user_lesson_progress",
+            UriComponentsBuilder.newInstance()
+                .queryParam("select", "id")
+                .queryParam("user_id", "eq." + userId)
+                .queryParam("lesson_id", "eq." + lessonId)
+                .queryParam("limit", 1)
+                .build().getQuery(),
+            requireToken(accessToken),
+            LESSON_PROGRESS_LIST
+        );
+
+        if (existing.isEmpty()) {
+            payload.put("user_id", userId);
+            payload.put("lesson_id", lessonId);
+            supabaseRestClient.postList("user_lesson_progress", payload, requireToken(accessToken), LESSON_PROGRESS_LIST);
+            return;
+        }
+
+        supabaseRestClient.patchList(
+            "user_lesson_progress",
+            UriComponentsBuilder.newInstance()
+                .queryParam("id", "eq." + existing.get(0).getId())
+                .build().getQuery(),
+            payload,
+            requireToken(accessToken),
+            LESSON_PROGRESS_LIST
+        );
+    }
+
+    private String requireToken(String accessToken) {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing access token");
+        }
+        return accessToken;
+    }
+
+    private int safeInt(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private String sanitizeLikeValue(String value) {
+        return value.replace(",", " ").replace("(", " ").replace(")", " ");
+    }
+}

--- a/src/main/java/com/rotiprata/domain/UserLessonProgress.java
+++ b/src/main/java/com/rotiprata/domain/UserLessonProgress.java
@@ -15,6 +15,8 @@ public class UserLessonProgress {
 
     private UUID userId;
 
+    private UUID lessonId;
+
     private Lesson lesson;
 
     private String status = "not_started";


### PR DESCRIPTION
### Motivation
- Provide the frontend with real lesson browsing/search/progress endpoints and a stable feed contract so the Lessons hub can show filtered, paginated data and user progress.
- Support upserting and retrieving per-user lesson progress and aggregate stats used by the lesson hub cards.
- Improve the Lessons UI with filters, loading/empty/error states and accessible labels so the page is robust when the backend is unavailable.

### Description
- Backend: added `LessonController` endpoints for `/api/lessons` (filters + pagination), `/api/lessons/feed` (paginated feed contract), `/api/lessons/search`, `/api/lessons/{id}`, `/users/me/lessons/progress`, `/users/me/stats`, and `PUT /lessons/{id}/progress` for upsert behavior.
- Backend: implemented `LessonService` which queries Supabase via `SupabaseRestClient` with `q`, `difficulty`, `maxMinutes` filters, pagination, counting, progress lookup, stats aggregation, and insert-or-update progress logic.
- Backend: added DTOs `LessonFeedResponse`, `LessonStatsResponse`, and `UpdateLessonProgressRequest`, and updated `UserLessonProgress` domain to include `lessonId` for clearer mapping.
- Frontend: extended `frontend/src/lib/api.ts` with `LessonFeedFilters` and dynamic query builder and updated callers to use the new feed API.
- Frontend: overhauled `LessonsPage.tsx` to add difficulty and duration filters, loading/empty/error UI, retry button, accessibility attributes (`aria-live`, labels, role/group), and a continue-learning section driven by progress.
- Tests/docs: added `frontend/src/test/lessons-page.test.tsx` unit tests for populated and empty states, and updated `docs/api.md` to document the new lesson endpoints and feed contract.

### Testing
- Ran frontend unit tests with `npm test` (Vitest); all tests passed (new `lessons-page` tests included). ✅
- Launched the frontend dev server (`npm run dev`) and captured a screenshot of the updated Lessons page; artifact produced. ✅
- Attempted backend compile with `mvn -q -DskipTests compile` but the environment could not download the Spring Boot parent POM (Maven Central returned 403), so the Java build could not be validated here. ⚠️
- Ran `npm run lint` during work; initial lint issues in unrelated shared UI files were observed (these pre-existed the feature), and core changes were adjusted to reduce React hook/lint issues where applicable. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999e07d9b4c832e8bed9f9b6d7ea634)