### PR TITLE
Add Maven repository connectivity preflight to dev startup script

### DIFF
--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -28,6 +28,39 @@ install_if_missing() {
   fi
 }
 
+check_maven_repo_access() {
+  local settings_file="$repo_root/.mvn/settings.xml"
+  local maven_args=("-q" "-DforceStdout" "help:evaluate" "-Dexpression=settings.localRepository")
+
+  if [[ -f "$settings_file" ]]; then
+    maven_args=("-s" "$settings_file" "${maven_args[@]}")
+  fi
+
+  if mvn "${maven_args[@]}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  cat <<'EOF'
+Maven could not reach dependency repositories.
+If you are behind a corporate/school proxy, add a project-level mirror in `.mvn/settings.xml`.
+Example:
+
+<settings>
+  <mirrors>
+    <mirror>
+      <id>internal-repo</id>
+      <name>Internal Maven Mirror</name>
+      <url>https://YOUR_MIRROR/repository/maven-public/</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>
+
+Then re-run `bash ./scripts/dev-start.sh`.
+EOF
+  exit 1
+}
+
 echo "Ensuring prerequisites (Java, Maven, Node.js)..."
 install_if_missing "java" "openjdk@17"
 install_if_missing "mvn" "maven"
@@ -47,6 +80,9 @@ fi
 echo "Installing media tools..."
 xattr -dr com.apple.quarantine "$repo_root/scripts/install-media-tools.sh" 2>/dev/null || true
 bash "$repo_root/scripts/install-media-tools.sh"
+
+echo "Checking Maven repository access..."
+check_maven_repo_access
 
 echo "Starting backend + frontend..."
 if command -v osascript >/dev/null 2>&1; then


### PR DESCRIPTION
### Motivation
- Running `mvn spring-boot:run` during one-step dev startup failed when Maven Central was unreachable through a proxy, causing confusing parent-POM download errors.
- The startup flow should detect repository connectivity early and provide actionable guidance instead of launching services that later fail.

### Description
- Added a `check_maven_repo_access` function to `scripts/dev-start.sh` that runs a lightweight `mvn help:evaluate -Dexpression=settings.localRepository` probe and respects a project-level `.mvn/settings.xml` if present.
- When the probe fails the script prints a clear message and a copy-paste `.mvn/settings.xml` mirror example and then exits with a non-zero status.
- The preflight is invoked after media tooling installation and before starting the backend and frontend processes to fail fast on dependency-resolution issues.

### Testing
- Ran `bash -n scripts/dev-start.sh` to validate shell syntax and it succeeded.
- Executed `mvn -q -DskipTests spring-boot:run` in this environment and it failed due to blocked repository access (403/proxy), demonstrating the exact condition the preflight detects.
- The new preflight was exercised locally in the modified script and prints the remediation guidance when Maven cannot reach repositories.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0f5354d483328beb7d5e6beb6ebf)