### PR TITLE
Allow admins to edit all lessons and fix create-lesson redirect

### DIFF
--- a/frontend/src/pages/admin/AdminLessonsPage.tsx
+++ b/frontend/src/pages/admin/AdminLessonsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft, Loader2, Pencil, Trash2 } from 'lucide-react';
 import { MainLayout } from '@/components/layout/MainLayout';
@@ -16,11 +16,9 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { deleteLesson, fetchAdminLessons, updateLesson } from '@/lib/api';
-import { useAuth } from '@/hooks/useAuth';
 import type { Lesson } from '@/types';
 
 const AdminLessonsPage = () => {
-  const { user } = useAuth();
   const [lessons, setLessons] = useState<Lesson[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -41,14 +39,6 @@ const AdminLessonsPage = () => {
       .catch((error) => console.warn('Failed to load admin lessons', error))
       .finally(() => setIsLoading(false));
   }, []);
-
-  const myLessons = useMemo(() => {
-    const userId = user?.user_id ?? user?.id;
-    if (!userId) {
-      return [];
-    }
-    return lessons.filter((lesson) => lesson.created_by === userId || lesson.created_by === user?.id);
-  }, [lessons, user]);
 
   const openEdit = (lesson: Lesson) => {
     setSelectedLesson(lesson);
@@ -105,7 +95,7 @@ const AdminLessonsPage = () => {
             </Link>
             <div>
               <h1 className="text-2xl font-bold">Manage Lessons</h1>
-              <p className="text-muted-foreground">Edit or delete lessons you created.</p>
+              <p className="text-muted-foreground">Admins can edit or delete any lesson, including pre-existing ones.</p>
             </div>
           </div>
           <Link to="/admin/lessons/create">
@@ -115,17 +105,17 @@ const AdminLessonsPage = () => {
 
         <Card>
           <CardHeader>
-            <CardTitle>Your Lessons ({myLessons.length})</CardTitle>
+            <CardTitle>All Lessons ({lessons.length})</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             {isLoading ? (
               <div className="flex items-center gap-2 text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" /> Loading lessons...
               </div>
-            ) : myLessons.length === 0 ? (
-              <p className="text-muted-foreground">No lessons created by you yet.</p>
+            ) : lessons.length === 0 ? (
+              <p className="text-muted-foreground">No lessons available yet.</p>
             ) : (
-              myLessons.map((lesson) => (
+              lessons.map((lesson) => (
                 <div key={lesson.id} className="border rounded-lg p-4 flex items-start justify-between gap-4">
                   <div>
                     <p className="font-semibold">{lesson.title}</p>

--- a/frontend/src/pages/admin/CreateLessonPage.tsx
+++ b/frontend/src/pages/admin/CreateLessonPage.tsx
@@ -134,7 +134,7 @@ const CreateLessonPage = () => {
         await createLessonQuiz(lesson.id, quizQuestions);
       }
 
-      navigate('/admin');
+      navigate('/admin/lessons');
     } catch (error) {
       console.warn('Create lesson failed', error);
     } finally {

--- a/src/main/java/com/rotiprata/application/LessonService.java
+++ b/src/main/java/com/rotiprata/application/LessonService.java
@@ -120,7 +120,6 @@ public class LessonService {
         ensureAdmin(userId, token);
 
         Map<String, Object> lesson = getLessonById(lessonId, token);
-        ensureLessonOwnerOrAdmin(userId, lesson, token);
 
         Map<String, Object> patch = new LinkedHashMap<>();
         copyIfPresent(payload, patch, "title");
@@ -160,8 +159,7 @@ public class LessonService {
         String token = requireAccessToken(accessToken);
         ensureAdmin(userId, token);
 
-        Map<String, Object> lesson = getLessonById(lessonId, token);
-        ensureLessonOwnerOrAdmin(userId, lesson, token);
+        getLessonById(lessonId, token);
 
         supabaseRestClient.deleteList(
             "lessons",
@@ -387,23 +385,6 @@ public class LessonService {
         }
     }
 
-
-    private void ensureLessonOwnerOrAdmin(UUID userId, Map<String, Object> lesson, String accessToken) {
-        Object createdBy = lesson.get("created_by");
-        if (createdBy != null && userId.toString().equals(createdBy.toString())) {
-            return;
-        }
-
-        List<Map<String, Object>> roles = supabaseRestClient.getList(
-            "user_roles",
-            buildQuery(Map.of("select", "id", "user_id", "eq." + userId, "role", "eq.super_admin")),
-            accessToken,
-            MAP_LIST
-        );
-        if (roles.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You can only edit lessons you created");
-        }
-    }
 
     private void addSection(List<Map<String, Object>> sections, String id, String title, Object rawContent, int order) {
         String content = stringify(rawContent);


### PR DESCRIPTION
### Motivation
- Admins should be able to edit pre-existing lessons as well as lessons they create, and the admin UI should expose an edit action for those lessons. 
- The create-lesson flow should return the user to the admin lessons list so newly created lessons are immediately visible.
- The backend must enforce that only admin roles can mutate lessons, not limit edits to the lesson owner or super-admin fallback.

### Description
- Frontend: changed `AdminLessonsPage` to list all lessons returned by `fetchAdminLessons` (removed per-user filtering) and updated the header copy to clarify admins can manage any lesson. 
- Frontend: updated `CreateLessonPage` to navigate to `/admin/lessons` after a successful `createLesson` so the new lesson appears in the management view. 
- Backend: updated `LessonService` to remove the owner-or-super-admin check from `updateLesson` and `deleteLesson`, leaving the `ensureAdmin` requirement so only users with admin roles can perform updates/deletes. 

### Testing
- Ran frontend production build with `npm run build` which completed successfully. 
- Started the frontend dev server with `npm run dev` and captured a screenshot of the admin lessons page to validate the UI changes. 
- Attempted backend compile with `mvn -q -DskipTests compile` which failed due to an environment dependency download restriction (Maven Central returned HTTP 403), so backend compilation could not be validated locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b137f637c833286c3e1318d4d10be)