### PR TITLE
Fix admin lesson list/create by using service-role Supabase client and update admin UI

### DIFF
--- a/frontend/src/pages/admin/AdminLessonsPage.tsx
+++ b/frontend/src/pages/admin/AdminLessonsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft, Loader2, Pencil, Trash2 } from 'lucide-react';
 import { MainLayout } from '@/components/layout/MainLayout';
@@ -16,11 +16,9 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { deleteLesson, fetchAdminLessons, updateLesson } from '@/lib/api';
-import { useAuth } from '@/hooks/useAuth';
 import type { Lesson } from '@/types';
 
 const AdminLessonsPage = () => {
-  const { user } = useAuth();
   const [lessons, setLessons] = useState<Lesson[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -41,14 +39,6 @@ const AdminLessonsPage = () => {
       .catch((error) => console.warn('Failed to load admin lessons', error))
       .finally(() => setIsLoading(false));
   }, []);
-
-  const myLessons = useMemo(() => {
-    const userId = user?.user_id ?? user?.id;
-    if (!userId) {
-      return [];
-    }
-    return lessons.filter((lesson) => lesson.created_by === userId || lesson.created_by === user?.id);
-  }, [lessons, user]);
 
   const openEdit = (lesson: Lesson) => {
     setSelectedLesson(lesson);
@@ -105,7 +95,7 @@ const AdminLessonsPage = () => {
             </Link>
             <div>
               <h1 className="text-2xl font-bold">Manage Lessons</h1>
-              <p className="text-muted-foreground">Edit or delete lessons you created.</p>
+              <p className="text-muted-foreground">Admins can edit or delete any lesson, including pre-existing ones.</p>
             </div>
           </div>
           <Link to="/admin/lessons/create">
@@ -115,17 +105,17 @@ const AdminLessonsPage = () => {
 
         <Card>
           <CardHeader>
-            <CardTitle>Your Lessons ({myLessons.length})</CardTitle>
+            <CardTitle>All Lessons ({lessons.length})</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             {isLoading ? (
               <div className="flex items-center gap-2 text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" /> Loading lessons...
               </div>
-            ) : myLessons.length === 0 ? (
-              <p className="text-muted-foreground">No lessons created by you yet.</p>
+            ) : lessons.length === 0 ? (
+              <p className="text-muted-foreground">No lessons available yet.</p>
             ) : (
-              myLessons.map((lesson) => (
+              lessons.map((lesson) => (
                 <div key={lesson.id} className="border rounded-lg p-4 flex items-start justify-between gap-4">
                   <div>
                     <p className="font-semibold">{lesson.title}</p>

--- a/frontend/src/pages/admin/CreateLessonPage.tsx
+++ b/frontend/src/pages/admin/CreateLessonPage.tsx
@@ -134,7 +134,7 @@ const CreateLessonPage = () => {
         await createLessonQuiz(lesson.id, quizQuestions);
       }
 
-      navigate('/admin');
+      navigate('/admin/lessons');
     } catch (error) {
       console.warn('Create lesson failed', error);
     } finally {


### PR DESCRIPTION
### Motivation
- Admin endpoints were still using user-token PostgREST calls which could be blocked by Supabase RLS, causing admins to see empty lists and failing `create` calls despite passing app-level admin checks. 
- The admin UI filtered lessons to the creating user and redirected to the wrong route after creation, preventing admins from seeing pre-existing lessons and newly created lessons in the management view.

### Description
- Backend: Injected `SupabaseAdminRestClient` into `LessonService` and switched admin-only flows to use it for listing, creating, updating, deleting lessons and creating quizzes so admin operations run with the service-role (bypass RLS) after calling `ensureAdmin` for app-level authorization. 
- Backend: Switched `ensureAdmin` role verification to read via the admin client and removed the `ensureLessonOwnerOrAdmin` owner-only guard so admins can manage any lesson. 
- Frontend: Updated `AdminLessonsPage` to list `lessons` directly (removed per-user filtering), updated header/copy to reflect admins can manage any lesson, and show the total count as `All Lessons ({lessons.length})`. 
- Frontend: Fixed `CreateLessonPage` post-create navigation to `'/admin/lessons'` so newly created lessons are visible in the admin management view.

### Testing
- Ran frontend production build with `npm run build` which completed successfully. 
- Attempted backend compile with `mvn -q -DskipTests compile` which failed due to external environment dependency resolution (Maven Central returned HTTP 403), so backend compilation could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b137f637c833286c3e1318d4d10be)