### PR TITLE
Fix admin lessons visibility and lesson create flow; expose real API errors

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -347,7 +347,7 @@ export const resolveFlag = (flagId: string) => apiPut<void>(`/admin/flags/${flag
 
 
 export const fetchAdminLessons = () =>
-  withMockFallback("admin-lessons", () => mockLessons, () => apiGet<Lesson[]>(`/admin/lessons`));
+  withMockFallback("admin-lessons", () => mockLessons, () => apiGet<Lesson[]>(`/admin/lessons`), { allowAutoFallback: false });
 
 export const updateLesson = (lessonId: string, payload: Record<string, unknown>) =>
   apiPut<Lesson>(`/admin/lessons/${lessonId}`, payload);

--- a/frontend/src/pages/admin/AdminLessonsPage.tsx
+++ b/frontend/src/pages/admin/AdminLessonsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft, Loader2, Pencil, Trash2 } from 'lucide-react';
 import { MainLayout } from '@/components/layout/MainLayout';
@@ -16,17 +16,16 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { deleteLesson, fetchAdminLessons, updateLesson } from '@/lib/api';
-import { useAuth } from '@/hooks/useAuth';
 import type { Lesson } from '@/types';
 
 const AdminLessonsPage = () => {
-  const { user } = useAuth();
   const [lessons, setLessons] = useState<Lesson[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [selectedLesson, setSelectedLesson] = useState<Lesson | null>(null);
   const [isEditOpen, setIsEditOpen] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [form, setForm] = useState({
     title: '',
     summary: '',
@@ -38,17 +37,12 @@ const AdminLessonsPage = () => {
   useEffect(() => {
     fetchAdminLessons()
       .then(setLessons)
-      .catch((error) => console.warn('Failed to load admin lessons', error))
+      .catch((error) => {
+        console.warn('Failed to load admin lessons', error);
+        setLoadError(error instanceof Error ? error.message : 'Failed to load lessons');
+      })
       .finally(() => setIsLoading(false));
   }, []);
-
-  const myLessons = useMemo(() => {
-    const userId = user?.user_id ?? user?.id;
-    if (!userId) {
-      return [];
-    }
-    return lessons.filter((lesson) => lesson.created_by === userId || lesson.created_by === user?.id);
-  }, [lessons, user]);
 
   const openEdit = (lesson: Lesson) => {
     setSelectedLesson(lesson);
@@ -105,7 +99,7 @@ const AdminLessonsPage = () => {
             </Link>
             <div>
               <h1 className="text-2xl font-bold">Manage Lessons</h1>
-              <p className="text-muted-foreground">Edit or delete lessons you created.</p>
+              <p className="text-muted-foreground">Admins can edit or delete any lesson, including pre-existing ones.</p>
             </div>
           </div>
           <Link to="/admin/lessons/create">
@@ -113,19 +107,21 @@ const AdminLessonsPage = () => {
           </Link>
         </div>
 
+        {loadError && <p className="text-sm text-destructive">{loadError}</p>}
+
         <Card>
           <CardHeader>
-            <CardTitle>Your Lessons ({myLessons.length})</CardTitle>
+            <CardTitle>All Lessons ({lessons.length})</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             {isLoading ? (
               <div className="flex items-center gap-2 text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" /> Loading lessons...
               </div>
-            ) : myLessons.length === 0 ? (
-              <p className="text-muted-foreground">No lessons created by you yet.</p>
+            ) : lessons.length === 0 ? (
+              <p className="text-muted-foreground">No lessons available yet.</p>
             ) : (
-              myLessons.map((lesson) => (
+              lessons.map((lesson) => (
                 <div key={lesson.id} className="border rounded-lg p-4 flex items-start justify-between gap-4">
                   <div>
                     <p className="font-semibold">{lesson.title}</p>

--- a/frontend/src/pages/admin/CreateLessonPage.tsx
+++ b/frontend/src/pages/admin/CreateLessonPage.tsx
@@ -24,6 +24,7 @@ import { createLesson, createLessonQuiz } from '@/lib/api';
 const CreateLessonPage = () => {
   const navigate = useNavigate();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [formData, setFormData] = useState({
     title: '',
     description: '',
@@ -122,6 +123,7 @@ const CreateLessonPage = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
+    setSubmitError(null);
 
     try {
       const lesson = await createLesson({
@@ -131,12 +133,17 @@ const CreateLessonPage = () => {
       });
 
       if (quizQuestions.length > 0) {
-        await createLessonQuiz(lesson.id, quizQuestions);
+        try {
+          await createLessonQuiz(lesson.id, quizQuestions);
+        } catch (quizError) {
+          console.warn('Create lesson quiz failed', quizError);
+        }
       }
 
-      navigate('/admin');
+      navigate('/admin/lessons');
     } catch (error) {
       console.warn('Create lesson failed', error);
+      setSubmitError(error instanceof Error ? error.message : 'Failed to create lesson');
     } finally {
       setIsSubmitting(false);
     }
@@ -154,6 +161,7 @@ const CreateLessonPage = () => {
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
+          {submitError && <p className="text-sm text-destructive">{submitError}</p>}
           {/* Basic Info */}
           <Card>
             <CardHeader>

--- a/src/main/java/com/rotiprata/application/LessonService.java
+++ b/src/main/java/com/rotiprata/application/LessonService.java
@@ -1,6 +1,7 @@
 package com.rotiprata.application;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.rotiprata.infrastructure.supabase.SupabaseAdminRestClient;
 import com.rotiprata.infrastructure.supabase.SupabaseRestClient;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -19,9 +20,11 @@ public class LessonService {
     private static final TypeReference<List<Map<String, Object>>> MAP_LIST = new TypeReference<>() {};
 
     private final SupabaseRestClient supabaseRestClient;
+    private final SupabaseAdminRestClient supabaseAdminRestClient;
 
-    public LessonService(SupabaseRestClient supabaseRestClient) {
+    public LessonService(SupabaseRestClient supabaseRestClient, SupabaseAdminRestClient supabaseAdminRestClient) {
         this.supabaseRestClient = supabaseRestClient;
+        this.supabaseAdminRestClient = supabaseAdminRestClient;
     }
 
     public List<Map<String, Object>> getLessons(String accessToken) {
@@ -38,7 +41,11 @@ public class LessonService {
     public List<Map<String, Object>> getAdminLessons(UUID userId, String accessToken) {
         String token = requireAccessToken(accessToken);
         ensureAdmin(userId, token);
-        return getLessons(token);
+        return supabaseAdminRestClient.getList(
+            "lessons",
+            buildQuery(Map.of("select", "*", "order", "created_at.desc")),
+            MAP_LIST
+        );
     }
 
     public List<Map<String, Object>> searchLessons(String query, String accessToken) {
@@ -106,8 +113,11 @@ public class LessonService {
         copyIfPresent(payload, insert, "evolution_content");
         copyIfPresent(payload, insert, "comparison_content");
         insert.put("is_published", true);
+        insert.put("completion_count", 0);
+        insert.put("created_at", OffsetDateTime.now());
+        insert.put("updated_at", OffsetDateTime.now());
 
-        List<Map<String, Object>> created = supabaseRestClient.postList("lessons", insert, token, MAP_LIST);
+        List<Map<String, Object>> created = supabaseAdminRestClient.postList("lessons", insert, MAP_LIST);
         if (created.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unable to create lesson");
         }
@@ -120,7 +130,6 @@ public class LessonService {
         ensureAdmin(userId, token);
 
         Map<String, Object> lesson = getLessonById(lessonId, token);
-        ensureLessonOwnerOrAdmin(userId, lesson, token);
 
         Map<String, Object> patch = new LinkedHashMap<>();
         copyIfPresent(payload, patch, "title");
@@ -142,12 +151,12 @@ public class LessonService {
         if (patch.isEmpty()) {
             return lesson;
         }
+        patch.put("updated_at", OffsetDateTime.now());
 
-        List<Map<String, Object>> updated = supabaseRestClient.patchList(
+        List<Map<String, Object>> updated = supabaseAdminRestClient.patchList(
             "lessons",
             buildQuery(Map.of("id", "eq." + lessonId)),
             patch,
-            token,
             MAP_LIST
         );
         if (updated.isEmpty()) {
@@ -160,13 +169,11 @@ public class LessonService {
         String token = requireAccessToken(accessToken);
         ensureAdmin(userId, token);
 
-        Map<String, Object> lesson = getLessonById(lessonId, token);
-        ensureLessonOwnerOrAdmin(userId, lesson, token);
+        getLessonById(lessonId, token);
 
-        supabaseRestClient.deleteList(
+        supabaseAdminRestClient.deleteList(
             "lessons",
             buildQuery(Map.of("id", "eq." + lessonId)),
-            token,
             MAP_LIST
         );
     }
@@ -184,7 +191,7 @@ public class LessonService {
         quizInsert.put("quiz_type", "multiple_choice");
         quizInsert.put("created_by", userId);
 
-        List<Map<String, Object>> quizzes = supabaseRestClient.postList("quizzes", quizInsert, token, MAP_LIST);
+        List<Map<String, Object>> quizzes = supabaseAdminRestClient.postList("quizzes", quizInsert, MAP_LIST);
         if (quizzes.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unable to create quiz");
         }
@@ -217,7 +224,7 @@ public class LessonService {
                 questionMap.put("order_index",
                         rawMap.getOrDefault("order_index", i));
         
-                supabaseRestClient.postList("quiz_questions", questionMap, token, MAP_LIST);
+                supabaseAdminRestClient.postList("quiz_questions", questionMap, MAP_LIST);
             }
         }
         
@@ -370,7 +377,7 @@ public class LessonService {
     }
 
     private void ensureAdmin(UUID userId, String accessToken) {
-        List<Map<String, Object>> roles = supabaseRestClient.getList(
+        List<Map<String, Object>> roles = supabaseAdminRestClient.getList(
             "user_roles",
             buildQuery(
                 Map.of(
@@ -379,7 +386,6 @@ public class LessonService {
                     "or", "(role.eq.admin,role.eq.super_admin)"
                 )
             ),
-            accessToken,
             MAP_LIST
         );
         if (roles.isEmpty()) {
@@ -387,23 +393,6 @@ public class LessonService {
         }
     }
 
-
-    private void ensureLessonOwnerOrAdmin(UUID userId, Map<String, Object> lesson, String accessToken) {
-        Object createdBy = lesson.get("created_by");
-        if (createdBy != null && userId.toString().equals(createdBy.toString())) {
-            return;
-        }
-
-        List<Map<String, Object>> roles = supabaseRestClient.getList(
-            "user_roles",
-            buildQuery(Map.of("select", "id", "user_id", "eq." + userId, "role", "eq.super_admin")),
-            accessToken,
-            MAP_LIST
-        );
-        if (roles.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You can only edit lessons you created");
-        }
-    }
 
     private void addSection(List<Map<String, Object>> sections, String id, String title, Object rawContent, int order) {
         String content = stringify(rawContent);


### PR DESCRIPTION
### Motivation
- Admin lesson listing and creation were unreliable: failures were being masked by a frontend mock fallback and backend inserts could fail when DB defaults/constraints differed from assumptions. 
- Admins need to see actual API errors and manage all lessons (not be filtered to the creating user). 

### Description
- Backend: inject `SupabaseAdminRestClient` into `LessonService` and use it for admin flows (`getAdminLessons`, `createLesson`, `updateLesson`, `deleteLesson`, `createLessonQuiz`, and `ensureAdmin`) so admin operations run with the service-role client. 
- Backend: on create, explicitly set `completion_count`, `created_at`, and `updated_at`; on update, stamp `updated_at` only when a real patch exists; remove owner-only guard so admins can manage any lesson. 
- Frontend: changed `fetchAdminLessons` to disable automatic mock fallback (`allowAutoFallback: false`) so real API failures are not silently hidden. 
- Frontend: added visible error display for admin lesson load failures, updated the management view to show all lessons and correct header copy, and made `CreateLessonPage` surface submit errors and make optional quiz creation non-blocking while navigating to `/admin/lessons` after successful lesson creation. 

### Testing
- Ran `npm run build` in `frontend` and the production build completed successfully. 
- Started the dev server (`npm run dev`) and captured a Playwright screenshot of `/admin/lessons` to validate UI changes. 
- Attempted `mvn -q -DskipTests compile` but compilation was blocked by external environment dependency resolution (Maven Central returned HTTP 403), so backend compilation could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b137f637c833286c3e1318d4d10be)