### PR TITLE
Fix enum mismatch in admin lesson authorization and admin flows

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -347,7 +347,7 @@ export const resolveFlag = (flagId: string) => apiPut<void>(`/admin/flags/${flag
 
 
 export const fetchAdminLessons = () =>
-  withMockFallback("admin-lessons", () => mockLessons, () => apiGet<Lesson[]>(`/admin/lessons`));
+  withMockFallback("admin-lessons", () => mockLessons, () => apiGet<Lesson[]>(`/admin/lessons`), { allowAutoFallback: false });
 
 export const updateLesson = (lessonId: string, payload: Record<string, unknown>) =>
   apiPut<Lesson>(`/admin/lessons/${lessonId}`, payload);

--- a/frontend/src/pages/admin/AdminLessonsPage.tsx
+++ b/frontend/src/pages/admin/AdminLessonsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft, Loader2, Pencil, Trash2 } from 'lucide-react';
 import { MainLayout } from '@/components/layout/MainLayout';
@@ -16,17 +16,16 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { deleteLesson, fetchAdminLessons, updateLesson } from '@/lib/api';
-import { useAuth } from '@/hooks/useAuth';
 import type { Lesson } from '@/types';
 
 const AdminLessonsPage = () => {
-  const { user } = useAuth();
   const [lessons, setLessons] = useState<Lesson[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [selectedLesson, setSelectedLesson] = useState<Lesson | null>(null);
   const [isEditOpen, setIsEditOpen] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [form, setForm] = useState({
     title: '',
     summary: '',
@@ -38,17 +37,12 @@ const AdminLessonsPage = () => {
   useEffect(() => {
     fetchAdminLessons()
       .then(setLessons)
-      .catch((error) => console.warn('Failed to load admin lessons', error))
+      .catch((error) => {
+        console.warn('Failed to load admin lessons', error);
+        setLoadError(error instanceof Error ? error.message : 'Failed to load lessons');
+      })
       .finally(() => setIsLoading(false));
   }, []);
-
-  const myLessons = useMemo(() => {
-    const userId = user?.user_id ?? user?.id;
-    if (!userId) {
-      return [];
-    }
-    return lessons.filter((lesson) => lesson.created_by === userId || lesson.created_by === user?.id);
-  }, [lessons, user]);
 
   const openEdit = (lesson: Lesson) => {
     setSelectedLesson(lesson);
@@ -105,7 +99,7 @@ const AdminLessonsPage = () => {
             </Link>
             <div>
               <h1 className="text-2xl font-bold">Manage Lessons</h1>
-              <p className="text-muted-foreground">Edit or delete lessons you created.</p>
+              <p className="text-muted-foreground">Admins can edit or delete any lesson, including pre-existing ones.</p>
             </div>
           </div>
           <Link to="/admin/lessons/create">
@@ -113,19 +107,21 @@ const AdminLessonsPage = () => {
           </Link>
         </div>
 
+        {loadError && <p className="text-sm text-destructive">{loadError}</p>}
+
         <Card>
           <CardHeader>
-            <CardTitle>Your Lessons ({myLessons.length})</CardTitle>
+            <CardTitle>All Lessons ({lessons.length})</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             {isLoading ? (
               <div className="flex items-center gap-2 text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" /> Loading lessons...
               </div>
-            ) : myLessons.length === 0 ? (
-              <p className="text-muted-foreground">No lessons created by you yet.</p>
+            ) : lessons.length === 0 ? (
+              <p className="text-muted-foreground">No lessons available yet.</p>
             ) : (
-              myLessons.map((lesson) => (
+              lessons.map((lesson) => (
                 <div key={lesson.id} className="border rounded-lg p-4 flex items-start justify-between gap-4">
                   <div>
                     <p className="font-semibold">{lesson.title}</p>

--- a/frontend/src/pages/admin/CreateLessonPage.tsx
+++ b/frontend/src/pages/admin/CreateLessonPage.tsx
@@ -24,6 +24,7 @@ import { createLesson, createLessonQuiz } from '@/lib/api';
 const CreateLessonPage = () => {
   const navigate = useNavigate();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [formData, setFormData] = useState({
     title: '',
     description: '',
@@ -122,6 +123,7 @@ const CreateLessonPage = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
+    setSubmitError(null);
 
     try {
       const lesson = await createLesson({
@@ -131,12 +133,17 @@ const CreateLessonPage = () => {
       });
 
       if (quizQuestions.length > 0) {
-        await createLessonQuiz(lesson.id, quizQuestions);
+        try {
+          await createLessonQuiz(lesson.id, quizQuestions);
+        } catch (quizError) {
+          console.warn('Create lesson quiz failed', quizError);
+        }
       }
 
-      navigate('/admin');
+      navigate('/admin/lessons');
     } catch (error) {
       console.warn('Create lesson failed', error);
+      setSubmitError(error instanceof Error ? error.message : 'Failed to create lesson');
     } finally {
       setIsSubmitting(false);
     }
@@ -154,6 +161,7 @@ const CreateLessonPage = () => {
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
+          {submitError && <p className="text-sm text-destructive">{submitError}</p>}
           {/* Basic Info */}
           <Card>
             <CardHeader>


### PR DESCRIPTION
### Motivation
- Admin lesson create/manage endpoints were failing with Postgres enum error `22P02` due to querying for a removed `super_admin` enum value.
- Admins should be able to view and manage all lessons, and real API errors must be surfaced instead of being hidden by frontend mock fallbacks.
- Backend inserts/patches assumed DB defaults that could mismatch and cause silent failures. 

### Description
- Backend: inject `SupabaseAdminRestClient` into `LessonService` and use it for admin flows (`getAdminLessons`, `createLesson`, `updateLesson`, `deleteLesson`, `createLessonQuiz`, and `ensureAdmin`) so admin operations run with the service-role client. 
- Backend: fixed the admin role filter in `ensureAdmin` to use `"role", "eq.admin"` (removed the invalid `super_admin` check) to avoid the enum mismatch error. 
- Backend: on create, explicitly set `completion_count`, `created_at`, and `updated_at`; on update, stamp `updated_at` only when a real patch exists; removed the owner-only guard so admins can manage any lesson. 
- Frontend: disabled automatic mock fallback for admin lessons by calling `fetchAdminLessons` with `{ allowAutoFallback: false }`, surfaced load/submit errors in `AdminLessonsPage` and `CreateLessonPage`, showed all lessons in management view, and made quiz creation non-blocking while navigating to `/admin/lessons` after successful lesson creation. 

### Testing
- Ran the frontend production build with `npm run build` in `frontend` and the build completed successfully. 
- Attempted to compile the backend with `mvn -q -DskipTests compile` but compilation was blocked by external dependency resolution (Maven Central returned HTTP 403), so backend compilation could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b137f637c833286c3e1318d4d10be)